### PR TITLE
REFACTOR: use name instead of id for tables

### DIFF
--- a/tests/whist/core/session/test_table.py
+++ b/tests/whist/core/session/test_table.py
@@ -7,7 +7,7 @@ from whist.core.user.player import Player
 class TableTestCase(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.table = Table(session_id=1, min_player=1, max_player=4)
+        self.table = Table(name='test table', min_player=1, max_player=4)
 
     def test_ready(self):
         self.table.join(self.player)
@@ -21,7 +21,7 @@ class TableTestCase(BaseTestCase):
         self.assertFalse(self.table.ready)
 
     def test_not_ready_min_player(self):
-        table = Table(session_id=1, min_player=2, max_player=4)
+        table = Table(name='test table', min_player=2, max_player=4)
         table.join(self.player)
         table.player_ready(self.player)
         self.assertFalse(table.ready)

--- a/whist/core/session/session.py
+++ b/whist/core/session/session.py
@@ -8,5 +8,5 @@ class Session(BaseModel):
     """
     User can join to play a game of Whist.
     """
-    session_id: int
+    name: str
     users: UserList = UserList()

--- a/whist/core/session/table.py
+++ b/whist/core/session/table.py
@@ -40,7 +40,7 @@ class Table(Session):
         if len(self.users) < self.max_player:
             self.users.append(player)
         else:
-            raise TableFullError(f'Table with ID: {self.session_id} is already full.')
+            raise TableFullError(f'Table with name: {self.name} is already full.')
 
     def leave(self, player: Player) -> None:
         """


### PR DESCRIPTION
This must not necessarily be unique. The server side can use unique IDs