### PR TITLE
UPDATE: disable fail fast test workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
         python-version: [ 3.9, '3.10' ]


### PR DESCRIPTION
We should be able to see if one specific python version fails.