### PR TITLE
Test Coverage fix for: bump pytest-cov from 3.0.0 to 4.0.0

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Test with pytest & coverage
-        uses: Whist-Team/actions/test-cov@v2
+        uses: Whist-Team/actions/test-cov@feature/coveragerc
         with:
           package: whist_core
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Will be closed by https://github.com/Whist-Team/actions/pull/5