### PR TITLE
FEATURE: next rubber

### DIFF
--- a/tests/whist_core/session/test_table.py
+++ b/tests/whist_core/session/test_table.py
@@ -64,19 +64,21 @@ class TableTestCase(BaseTestCase):
 
     def test_conversion(self):
         self.table.join(self.player)
-        table_dict = self.table.dict()
+        table_dict = self.table.dict(exclude={'matcher'})
         table = Table(**table_dict)
         self.assertEqual(self.table, table)
 
     def test_start_random(self):
+        table = Table(name='test table', min_player=1, max_player=4, matcher=RandomMatcher())
         second_player = Player(username='miles', rating=3000)
-        self.table.join(self.player)
-        self.table.join(second_player)
-        self.table.player_ready(self.player)
-        self.table.player_ready(second_player)
-        self.table.start(RandomMatcher)
-        self.assertTrue(self.table.started)
-        self.assertIsInstance(self.table.current_rubber, Rubber)
+        table.join(self.player)
+        table.join(second_player)
+        table.player_ready(self.player)
+        table.player_ready(second_player)
+        table.start()
+        self.assertTrue(table.started)
+        self.assertIsInstance(table.current_rubber, Rubber)
+        self.assertTrue(isinstance(table.matcher, RandomMatcher))
 
     def test_start_robin(self):
         second_player = Player(username='miles', rating=3000)
@@ -84,14 +86,15 @@ class TableTestCase(BaseTestCase):
         self.table.join(second_player)
         self.table.player_ready(self.player)
         self.table.player_ready(second_player)
-        self.table.start(RoundRobinMatcher)
+        self.table.start()
         self.assertTrue(self.table.started)
         self.assertIsInstance(self.table.current_rubber, Rubber)
+        self.assertTrue(isinstance(self.table.matcher, RoundRobinMatcher))
 
     def test_not_ready_start(self):
         self.table.join(self.player)
         with self.assertRaises(TableNotReadyError):
-            self.table.start(RandomMatcher)
+            self.table.start()
         self.assertFalse(self.table.started)
 
     def test_rubber_without_start(self):

--- a/tests/whist_core/session/test_table.py
+++ b/tests/whist_core/session/test_table.py
@@ -124,4 +124,14 @@ class TableTestCase(BaseTestCase):
         self.table.start()
         with self.assertRaises(RubberNotDoneError):
             self.table.next_rubber()
-        self.assertEqual(2, len(self.table.rubbers))
+        self.assertEqual(1, len(self.table.rubbers))
+
+    def test_next_rubber_first(self):
+        second_player = Player(username='miles', rating=3000)
+        self.table.join(self.player)
+        self.table.join(second_player)
+        self.table.player_ready(self.player)
+        self.table.player_ready(second_player)
+        with self.assertRaises(TableNotStartedError):
+            self.table.next_rubber()
+        self.assertEqual(0, len(self.table.rubbers))

--- a/whist_core/game/errors.py
+++ b/whist_core/game/errors.py
@@ -51,6 +51,12 @@ class NoTrumpSelectedError(Exception):
     """
 
 
+class RubberNotDoneError(Exception):
+    """
+    Raised if the current rubber is not done, but action requested requires it to be done.
+    """
+
+
 class TrickDoneError(Exception):
     """
     Raised when the trick is already done.

--- a/whist_core/session/matcher.py
+++ b/whist_core/session/matcher.py
@@ -4,13 +4,15 @@ Match making tool.
 import abc
 import random
 
+from pydantic import BaseModel
+
 from whist_core.error.matcher_error import NotEnoughPlayersError
 from whist_core.scoring.team import Team
 from whist_core.session.userlist import UserList
 
 
 # pylint: disable=too-few-public-methods
-class Matcher(abc.ABC):
+class Matcher(abc.ABC, BaseModel):
     """
     Abstrakt class for player to teams matching.
     """

--- a/whist_core/session/table.py
+++ b/whist_core/session/table.py
@@ -54,7 +54,16 @@ class Table(Session):
             raise TableNotStartedError()
         return self.rubbers[-1]
 
-    def start(self, matcher: Matcher) -> None:
+    def next_rubber(self) -> Rubber:
+        """
+        Creates the next rubber.
+        :return: the new rubber
+        """
+        if len(self.rubbers) == 0 or self.rubbers[-1].done:
+            self.rubbers.append(self._create_rubber())
+        return self.current_rubber
+
+    def start(self) -> None:
         """
         Starts the table, but will check if every player is ready first.
         """

--- a/whist_core/session/table.py
+++ b/whist_core/session/table.py
@@ -2,6 +2,7 @@
 
 from whist_core.error.table_error import TableFullError, TeamFullError, TableNotReadyError, \
     TableNotStartedError
+from whist_core.game.errors import RubberNotDoneError
 from whist_core.game.rubber import Rubber
 from whist_core.session.matcher import Matcher, RoundRobinMatcher
 from whist_core.session.session import Session
@@ -56,11 +57,15 @@ class Table(Session):
 
     def next_rubber(self) -> Rubber:
         """
-        Creates the next rubber.
+        Creates the next rubber. In order to create the first rubber use 'Table.start()'.
         :return: the new rubber
         """
-        if len(self.rubbers) == 0 or self.rubbers[-1].done:
+        if len(self.rubbers) == 0:
+            raise TableNotStartedError()
+        if self.rubbers[-1].done:
             self.rubbers.append(self._create_rubber())
+        else:
+            raise RubberNotDoneError()
         return self.current_rubber
 
     def start(self) -> None:


### PR DESCRIPTION
# Breaking Changes
`whist_core.session.table.Table` no longer expects `whist_core.session.matcher.Matcherˋ during `Table.start()` but during initialization. 