### PR TITLE
FIX: card dictionary

### DIFF
--- a/tests/whist_core/cards/test_card.py
+++ b/tests/whist_core/cards/test_card.py
@@ -22,6 +22,9 @@ class CardTestCase(unittest.TestCase):
         self.assertEqual('ace of hearts', str(self.card))
 
     def test_dict(self):
+        self.assertEqual({'suit': 'hearts', 'rank': 'ace'}, self.card.dict())
+
+    def test_dump(self):
         self.assertEqual({'suit': 'hearts', 'rank': 'ace'}, self.card.model_dump())
 
     def test_json(self):

--- a/tests/whist_core/cards/test_card.py
+++ b/tests/whist_core/cards/test_card.py
@@ -22,10 +22,10 @@ class CardTestCase(unittest.TestCase):
         self.assertEqual('ace of hearts', str(self.card))
 
     def test_dict(self):
-        self.assertEqual({'suit': 'hearts', 'rank': 'ace'}, self.card.dict())
+        self.assertEqual({'suit': 'hearts', 'rank': 'ace'}, self.card.model_dump())
 
     def test_json(self):
-        self.assertEqual({'suit': 'hearts', 'rank': 'ace'}, json.loads(self.card.json()))
+        self.assertEqual({'suit': 'hearts', 'rank': 'ace'}, json.loads(self.card.model_dump_json()))
 
     def test_constructor_with_enum_as_str(self):
         self.assertEqual(self.card, Card(suit='hearts', rank='ace'))

--- a/tests/whist_core/cards/test_card_container.py
+++ b/tests/whist_core/cards/test_card_container.py
@@ -70,7 +70,7 @@ class OrderedCardContainerTestCase(TestCase):
         self.assertEqual(cc, OrderedCardContainer(**json.loads(cc.model_dump_json())))
 
     def test_dump_string_conversion(self):
-        cc = OrderedCardContainer.with_cards(self.spades_king).model_dump()
+        cc = OrderedCardContainer.with_cards(self.spades_king).model_dump(mode='json')
         card = cc['cards'][0]
         self.assertEqual(str(self.spades_king.rank), card['rank'])
         self.assertEqual(str(self.spades_king.suit), card['suit'])

--- a/tests/whist_core/cards/test_card_container.py
+++ b/tests/whist_core/cards/test_card_container.py
@@ -12,11 +12,14 @@ class OrderedCardContainerTestCase(TestCase):
         self.ace_hearts = Card(suit=Suit.HEARTS, rank=Rank.A)
         self.seven_clubs = Card(suit=Suit.CLUBS, rank=Rank.NUM_7)
         self.ten_diamonds = Card(suit=Suit.DIAMONDS, rank=Rank.NUM_10)
-        self.cc4 = OrderedCardContainer.with_cards(self.king_hearts, self.ace_hearts, self.seven_clubs, self.ten_diamonds)
+        self.cc4 = OrderedCardContainer.with_cards(self.king_hearts, self.ace_hearts,
+                                                   self.seven_clubs, self.ten_diamonds)
 
     def test_not_equal(self):
-        first = OrderedCardContainer.with_cards(Card(suit=Suit.HEARTS, rank=Rank.NUM_2), Card(suit=Suit.HEARTS, rank=Rank.NUM_4))
-        second = OrderedCardContainer.with_cards(Card(suit=Suit.HEARTS, rank=Rank.NUM_4), Card(suit=Suit.HEARTS, rank=Rank.NUM_2))
+        first = OrderedCardContainer.with_cards(Card(suit=Suit.HEARTS, rank=Rank.NUM_2),
+                                                Card(suit=Suit.HEARTS, rank=Rank.NUM_4))
+        second = OrderedCardContainer.with_cards(Card(suit=Suit.HEARTS, rank=Rank.NUM_4),
+                                                 Card(suit=Suit.HEARTS, rank=Rank.NUM_2))
         self.assertNotEqual(first, second)
 
     def test_empty_manual(self):
@@ -39,11 +42,11 @@ class OrderedCardContainerTestCase(TestCase):
 
     def test_json_empty(self):
         cc = OrderedCardContainer.empty()
-        self.assertEqual({'cards': []}, json.loads(cc.json()))
+        self.assertEqual({'cards': []}, json.loads(cc.model_dump_json()))
 
     def test_json_empty_load(self):
         cc = OrderedCardContainer.empty()
-        self.assertEqual(cc, OrderedCardContainer(**json.loads(cc.json())))
+        self.assertEqual(cc, OrderedCardContainer(**json.loads(cc.model_dump_json())))
 
     def test_json_some_cards(self):
         cc = OrderedCardContainer.with_cards(
@@ -53,18 +56,24 @@ class OrderedCardContainerTestCase(TestCase):
         self.assertEqual({'cards': [
             {'suit': 'hearts', 'rank': '2'},
             {'suit': 'hearts', 'rank': '4'}
-        ]}, json.loads(cc.json()))
+        ]}, json.loads(cc.model_dump_json()))
 
     def test_json_some_cards_load(self):
         cc = OrderedCardContainer.with_cards(
             Card(suit=Suit.HEARTS, rank=Rank.NUM_2),
             Card(suit=Suit.HEARTS, rank=Rank.NUM_4)
         )
-        self.assertEqual(cc, OrderedCardContainer(**json.loads(cc.json())))
+        self.assertEqual(cc, OrderedCardContainer(**json.loads(cc.model_dump_json())))
 
     def test_json_full_load(self):
         cc = OrderedCardContainer.full()
-        self.assertEqual(cc, OrderedCardContainer(**json.loads(cc.json())))
+        self.assertEqual(cc, OrderedCardContainer(**json.loads(cc.model_dump_json())))
+
+    def test_dump_string_conversion(self):
+        cc = OrderedCardContainer.with_cards(self.spades_king).model_dump()
+        card = cc['cards'][0]
+        self.assertEqual(str(self.spades_king.rank), card['rank'])
+        self.assertEqual(str(self.spades_king.suit), card['suit'])
 
     def test_contains(self):
         cc = OrderedCardContainer.with_cards(self.spades_king)
@@ -165,8 +174,10 @@ class UnorderedCardContainerTestCase(TestCase):
         self.spades_king = Card(suit=Suit.SPADES, rank=Rank.K)
 
     def test_equal(self):
-        first = UnorderedCardContainer.with_cards(Card(suit=Suit.HEARTS, rank=Rank.NUM_2), Card(suit=Suit.HEARTS, rank=Rank.NUM_4))
-        second = UnorderedCardContainer.with_cards(Card(suit=Suit.HEARTS, rank=Rank.NUM_4), Card(suit=Suit.HEARTS, rank=Rank.NUM_2))
+        first = UnorderedCardContainer.with_cards(Card(suit=Suit.HEARTS, rank=Rank.NUM_2),
+                                                  Card(suit=Suit.HEARTS, rank=Rank.NUM_4))
+        second = UnorderedCardContainer.with_cards(Card(suit=Suit.HEARTS, rank=Rank.NUM_4),
+                                                   Card(suit=Suit.HEARTS, rank=Rank.NUM_2))
         self.assertEqual(first, second)
 
     def test_not_equal(self):

--- a/whist_core/cards/card.py
+++ b/whist_core/cards/card.py
@@ -136,8 +136,7 @@ class Card(BaseModel, frozen=True):
         """
         return f'{self.rank} of {self.suit}'
 
-        @deprecation.deprecated("Use model_dump instead. Will be removed in V1.")
-
+    @deprecation.deprecated("Use model_dump instead. Will be removed in V1.")
     def dict(self, *args, **kwargs):
         """
         Returns the dictionary. See BaseModel for details.

--- a/whist_core/cards/card.py
+++ b/whist_core/cards/card.py
@@ -4,6 +4,7 @@ from enum import Enum
 from functools import total_ordering
 from typing import Any, Optional, Iterator
 
+import deprecation
 from pydantic import BaseModel
 
 from whist_core.util import enforce_str_on_dict
@@ -135,7 +136,16 @@ class Card(BaseModel, frozen=True):
         """
         return f'{self.rank} of {self.suit}'
 
+        @deprecation.deprecated("Use model_dump instead. Will be removed in V1.")
+
     def dict(self, *args, **kwargs):
+        """
+        Returns the dictionary. See BaseModel for details.
+        """
+        super_dict = super().model_dump(*args, **kwargs)
+        return enforce_str_on_dict(super_dict, ('suit', 'rank'))
+
+    def model_dump(self, *args, **kwargs):
         """
         Returns the dictionary. See BaseModel for details.
         """

--- a/whist_core/cards/card_container.py
+++ b/whist_core/cards/card_container.py
@@ -6,7 +6,6 @@ from typing import Iterator, Optional
 from pydantic import BaseModel, PrivateAttr
 
 from whist_core.cards.card import Card, Suit
-from whist_core.util import enforce_str_on_dict
 
 
 class CardContainer(BaseModel, abc.ABC, frozen=True):
@@ -58,15 +57,6 @@ class CardContainer(BaseModel, abc.ABC, frozen=True):
         card = random.choice(self.cards)  # nosec random
         self.remove(card)
         return card
-
-    def model_dump(self, *args, **kwargs):
-        """
-        Returns the dictionary. See BaseModel for details.
-        """
-        super_dict = super().model_dump(*args, **kwargs)
-        super_dict['cards'] = tuple(
-            enforce_str_on_dict(card, ('suit', 'rank')) for card in super_dict['cards'])
-        return super_dict
 
     def __contains__(self, card: Card) -> bool:
         """Returns if a card is in container. True if yes else False."""

--- a/whist_core/cards/card_container.py
+++ b/whist_core/cards/card_container.py
@@ -6,6 +6,7 @@ from typing import Iterator, Optional
 from pydantic import BaseModel, PrivateAttr
 
 from whist_core.cards.card import Card, Suit
+from whist_core.util import enforce_str_on_dict
 
 
 class CardContainer(BaseModel, abc.ABC, frozen=True):
@@ -57,6 +58,15 @@ class CardContainer(BaseModel, abc.ABC, frozen=True):
         card = random.choice(self.cards)  # nosec random
         self.remove(card)
         return card
+
+    def model_dump(self, *args, **kwargs):
+        """
+        Returns the dictionary. See BaseModel for details.
+        """
+        super_dict = super().model_dump(*args, **kwargs)
+        super_dict['cards'] = tuple(
+            enforce_str_on_dict(card, ('suit', 'rank')) for card in super_dict['cards'])
+        return super_dict
 
     def __contains__(self, card: Card) -> bool:
         """Returns if a card is in container. True if yes else False."""


### PR DESCRIPTION
Due to the override of methods Suit and Rank were not converted to strings.